### PR TITLE
Migrate to Readwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pocket Retro
+# Readwise Retro
 
 Pocket updated their design recently. I love it but it has affected my main usecase for Pocket.
 

--- a/api.py
+++ b/api.py
@@ -1,13 +1,13 @@
 import json
 import logging
-from urllib.parse import urlparse
+import os
 
 import bottle
 import requests
 
 FRONTEND_DIST_DIR = "./frontend/dist"
 READWISE_TOKEN = os.environ['READWISE_TOKEN']
-HEADERS = {"X-Accept": "application/json", "Authorization": f"Token {TOKEN}"}
+HEADERS = {"X-Accept": "application/json", "Authorization": f"Token {READWISE_TOKEN}"}
 
 
 class JSONErrorBottle(bottle.Bottle):
@@ -55,7 +55,6 @@ def archive_article(article_id):
         headers=HEADERS,
         json={"location": "archive"},
     )
-    
     bottle.response.status = rv.status_code
     bottle.response.content_type = "application/json"
     return {}
@@ -71,10 +70,18 @@ def get_articles():
 
     try:
         items = list(content["results"])
-    except AttributeError:
+    except (KeyError, TypeError):
         items = []
 
-    return {"articles": [{"id": obj['id'], 'url': obj['source_url'], 'title': obj['title'] or obj['source_url'], 'excerpt': ''} for obj in items]}
+    return {"articles": [
+        {
+            "id": obj['id'],
+            "url": obj['source_url'],
+            "title": obj['title'] or obj['source_url'],
+            "excerpt": '',
+        }
+        for obj in items
+    ]}
 
 
 try:

--- a/api.py
+++ b/api.py
@@ -6,13 +6,8 @@ import bottle
 import requests
 
 FRONTEND_DIST_DIR = "./frontend/dist"
-POCKET_HEADERS = {"X-Accept": "application/json"}
-GET_URL = "https://getpocket.com/v3/get"
-ARCHIVE_URL = "https://getpocket.com/v3/send"
-READ_POCKET_URL = "https://getpocket.com/read"
-REQUEST_URL = "https://getpocket.com/v3/oauth/request"
-AUTHORIZE_URL = "https://getpocket.com/v3/oauth/authorize"
-PAYWALL_DOMAINS = set(["www.economist.com", "www.barrons.com"])
+READWISE_TOKEN = os.environ['READWISE_TOKEN']
+HEADERS = {"X-Accept": "application/json", "Authorization": f"Token {TOKEN}"}
 
 
 class JSONErrorBottle(bottle.Bottle):
@@ -49,140 +44,43 @@ def serve_static(filename="index.html"):
     return bottle.static_file(filename, root=FRONTEND_DIST_DIR)
 
 
-def authenticated(func):
-    def wrapped(*args, **kwargs):
-        try:
-            key = bottle.request.cookies["consumer_key"]
-            token = bottle.request.cookies["access_token"]
-        except KeyError:
-            raise bottle.HTTPError(403, "failed getting cookies")
-
-        credentials = dict(consumer_key=key, access_token=token)
-        return func(credentials, *args, **kwargs)
-
-    return wrapped
-
-
 api = JSONErrorBottle()
 app.mount("/api", api)
 
 
-@api.post("/oauth/request")
-def request_oauth():
-    forms = bottle.request.forms
-    try:
-        consumer_key = forms["consumer_key"]
-        redirect_uri = forms["redirect_uri"]
-    except KeyError:
-        raise bottle.HTTPError(400, "requires consumer key")
-
-    post_body = dict(redirect_uri=redirect_uri, consumer_key=consumer_key)
-    rv = requests.post(REQUEST_URL, json=post_body, headers=POCKET_HEADERS)
-
-    try:
-        req_token = rv.json()["code"]
-    except (KeyError, json.decoder.JSONDecodeError):
-        raise bottle.HTTPError(rv.status_code, rv.text)
-
-    link = (
-        "https://getpocket.com/auth/authorize"
-        f"?request_token={req_token}&redirect_uri={redirect_uri}"
+@api.delete("/articles/<article_id>")
+def archive_article(article_id):
+    rv = requests.patch(
+        f'https://readwise.io/api/v3/update/{article_id}/',
+        headers=HEADERS,
+        json={"location": "archive"},
     )
-
-    bottle.response.set_cookie(
-        name="consumer_key", value=consumer_key, httponly=True, path="/"
-    )
-    bottle.response.set_cookie(
-        name="request_token", value=req_token, httponly=True, path="/"
-    )
-    return {"link": link}
-
-
-@api.post("/oauth/authorize")
-def authorize_oauth():
-    try:
-        key = bottle.request.cookies["consumer_key"]
-        token = bottle.request.cookies["request_token"]
-    except KeyError:
-        raise bottle.HTTPError(403, "failed getting cookies")
-
-    auth_body = dict(consumer_key=key, code=token)
-    rv = requests.post(AUTHORIZE_URL, json=auth_body, headers=POCKET_HEADERS)
-    try:
-        access_token = rv.json()["access_token"]
-    except (KeyError, json.decoder.JSONDecodeError):
-        raise bottle.HTTPError(rv.status_code, rv.text)
-
-    bottle.response.set_cookie(
-        name="access_token", value=access_token, httponly=True, path="/"
-    )
+    
     bottle.response.status = rv.status_code
+    bottle.response.content_type = "application/json"
     return {}
 
 
 @api.get("/articles")
-@authenticated
-def get_articles(credentials):
-    query_args = bottle.request.query
-    limit = query_args.get("limit", default=25)
-    offset = query_args.get("offset", default=0)
-
-    req_data = {
-        **credentials,
-        "count": limit,
-        "offset": offset,
-        "detailType": "simple",
-        "state": "unread",
-        "sort": "newest",
-    }
-
-    rv = requests.post(GET_URL, data=req_data)
+def get_articles():
+    rv = requests.get('https://readwise.io/api/v3/list/', headers=HEADERS, params={'location': 'new'})
     try:
         content = rv.json()
     except json.decoder.JSONDecodeError:
         raise bottle.HTTPError(rv.status_code, rv.text)
 
     try:
-        items = list(content["list"].values())
+        items = list(content["results"])
     except AttributeError:
         items = []
 
-    def build_article(obj):
-        # TODO: which url is better?
-        url = obj.get("given_url") or obj.get("resolved_url")
-        use_pocket_view = (
-            obj.get("is_article", False) and urlparse(url).netloc in PAYWALL_DOMAINS
-        )
-        return {
-            "id": obj["item_id"],
-            "excerpt": obj.get("excerpt", ""),
-            "title": obj.get("given_title") or obj.get("resolved_title") or url,
-            "url": f'{READ_POCKET_URL}/{obj["item_id"]}' if use_pocket_view else url,
-        }
-
-    return {"articles": [build_article(i) for i in items]}
-
-
-@api.delete("/articles/<article_id>")
-@authenticated
-def archive_article(credentials, article_id):
-    rv = requests.post(
-        ARCHIVE_URL,
-        data={
-            **credentials,
-            "actions": json.dumps([{"action": "archive", "item_id": article_id}]),
-        },
-    )
-
-    bottle.response.status = rv.status_code
-    bottle.response.content_type = "application/json"
-    return {}
+    return {"articles": [{"id": obj['id'], 'url': obj['source_url'], 'title': obj['title'] or obj['source_url'], 'excerpt': ''} for obj in items]}
 
 
 try:
     import cheroot
-
     server = "cheroot"
 except ImportError:
     server = "wsgiref"
-app.run(host="0.0.0.0", port=8080, server=server, quiet=True)
+
+app.run(host="0.0.0.0", port=8080, server=server, quiet=False)

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,3 @@
 dist
+node_modules
 vite.config.js.timestamp*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,30 @@ import React, { useState, useEffect } from "react";
 import { Form } from "./components/forms";
 import { Article, ArticleItem } from "./components/articles";
 
+type BlockingErrorProps = {
+  message: string;
+  onConfirm: () => void;
+};
+
+const BlockingErrorDialog: React.FC<BlockingErrorProps> = ({
+  message,
+  onConfirm,
+}) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
+    <div className="bg-gray-900 border border-orange-500 text-orange-500 px-6 py-4 w-11/12 max-w-md shadow-lg">
+      <p className="mb-4 text-center">{message}</p>
+      <button
+        className="w-full border border-orange-500 px-3 py-2 uppercase font-bold tracking-wide"
+        onClick={onConfirm}
+        autoFocus
+        type="button"
+      >
+        Confirm
+      </button>
+    </div>
+  </div>
+);
+
 const parseJSON = (response: any) => {
   return new Promise((resolve) =>
     response.json().then((data: any) =>
@@ -48,6 +72,9 @@ const App: React.FC = () => {
   const [errorMessage, setErrorMessage]: [string, Function] = useState("");
   const [isAuthenticated, setIsAuthenticated]: [boolean, Function] =
     useState(true);
+  const [blockingErrorMessage, setBlockingErrorMessage] = useState<
+    string | null
+  >(null);
 
   const urlParams = new URLSearchParams(window.location.search);
   const isRedirected = urlParams.get("callback") !== null;
@@ -142,12 +169,18 @@ const App: React.FC = () => {
         }
         setArticles((existing: Article[]) => articles);
       })
-      .catch(({ status, message }) => {
+      .catch((error) => {
+        const { status, message } = error || {};
+        const effectiveMessage =
+          message ||
+          (status
+            ? `Request failed with status ${status}.`
+            : "Request failed. Please try again.");
+        setBlockingErrorMessage(effectiveMessage);
         if (status === 403) {
           setIsAuthenticated(false);
-        } else {
-          setErrorMessage(message);
         }
+        setErrorMessage(effectiveMessage);
       })
       .then(() => setIsFetching(false));
   };
@@ -159,9 +192,16 @@ const App: React.FC = () => {
   const handleClick = (id: string) => {
     // list will only contain at most 10 elements so filter is fine.
     setArticles((existing: Article[]) => existing.filter((a) => a.id !== id));
-    request(`/api/articles/${id}`, { method: "DELETE" }).catch(() =>
-      setErrorMessage("Failure to archive article. Check API.")
-    );
+    request(`/api/articles/${id}`, { method: "DELETE" }).catch((error) => {
+      const { status, message } = error || {};
+      const effectiveMessage =
+        message ||
+        (status
+          ? `Failed to archive article (status ${status}).`
+          : "Failed to archive article. Check API.");
+      setBlockingErrorMessage(effectiveMessage);
+      setErrorMessage(effectiveMessage);
+    });
   };
 
   const LimitSection = () => {
@@ -190,6 +230,12 @@ const App: React.FC = () => {
 
   return (
     <div className="h-screen flex items-center flex-col font-mono p-1">
+      {blockingErrorMessage && (
+        <BlockingErrorDialog
+          message={blockingErrorMessage}
+          onConfirm={() => setBlockingErrorMessage(null)}
+        />
+      )}
       <div className="flex-grow-0 sm:w-2/3 md:w-1/2 text-center bg-orange-500 uppercase font-bold mt-4">
         $ WELCOME TO POCKET RETRO
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 
-import { Form } from "./components/forms";
 import { Article, ArticleItem } from "./components/articles";
 
 type BlockingErrorProps = {
@@ -66,18 +65,12 @@ const request = (url: string, options: any) => {
 
 const App: React.FC = () => {
   const [articleLimit, setArticleLimit] = useState<number>(30);
-  const [consumerKey, setConsumerKey] = useState<null | string>(null);
   const [allArticles, setArticles]: [Article[], Function] = useState([]);
   const [isFetching, setIsFetching]: [boolean, Function] = useState(false);
   const [errorMessage, setErrorMessage]: [string, Function] = useState("");
-  const [isAuthenticated, setIsAuthenticated]: [boolean, Function] =
-    useState(true);
   const [blockingErrorMessage, setBlockingErrorMessage] = useState<
     string | null
   >(null);
-
-  const urlParams = new URLSearchParams(window.location.search);
-  const isRedirected = urlParams.get("callback") !== null;
 
   const updateArticleLimit = (newLimit: number) => {
     const [MIN, MAX]: number[] = [5, 50];
@@ -86,17 +79,7 @@ const App: React.FC = () => {
     localStorage.setItem("articleLimit", limit.toString());
   };
 
-  const removeKey = () => {
-    setConsumerKey(null);
-    setIsAuthenticated(false);
-    localStorage.removeItem("consumerKey");
-  };
-
   useEffect(() => {
-    const key = localStorage.getItem("consumerKey");
-    if (key !== null) {
-      setConsumerKey(key);
-    }
     const limit: null | string = localStorage.getItem("articleLimit");
     if (limit !== null && parseInt(limit, 10)) {
       updateArticleLimit(parseInt(limit, 10));
@@ -110,55 +93,9 @@ const App: React.FC = () => {
   }, [articleLimit]);
 
   useEffect(() => {
-    // on consumerKey changes. runs multiple times here..
-    if (consumerKey !== null) {
-      setConsumerKey(consumerKey);
-      localStorage.setItem("consumerKey", consumerKey);
-      setIsAuthenticated(true);
-    }
-  }, [consumerKey]);
-
-  useEffect(() => {
-    if (consumerKey !== null && !isAuthenticated) {
-      if (!isRedirected) {
-        const callbackURL = new URL(window.location.href);
-        callbackURL.searchParams.append("callback", "");
-        const formData = new FormData();
-        formData.append("consumer_key", consumerKey);
-        formData.append("redirect_uri", callbackURL.toString());
-        request(`/api/oauth/request`, { method: "POST", body: formData })
-          .then((res: any) => {
-            const link = res.data["link"];
-            window.open(link);
-          })
-          .catch((_) => {
-            setErrorMessage("Failed to authenticate");
-          });
-      } else {
-        request(`/api/oauth/authorize`, { method: "POST" })
-          .then((res: any) => {
-            setIsAuthenticated(true);
-          })
-          .catch((e) => {
-            console.log(e);
-            setErrorMessage(
-              "Request token was not authorized to obtain access token"
-            );
-          });
-      }
-    }
-  }, [consumerKey, isAuthenticated]);
-
-  useEffect(() => {
-    if (
-      allArticles.length !== 0 ||
-      errorMessage ||
-      !isAuthenticated ||
-      consumerKey === null
-    )
-      return;
+    if (allArticles.length !== 0 || errorMessage) return;
     setIsFetching(true);
-  }, [allArticles, errorMessage, isAuthenticated, consumerKey]);
+  }, [allArticles, errorMessage]);
 
   const fetchArticles = () => {
     return request(`/api/articles?offset=0&limit=${articleLimit}`, {})
@@ -177,9 +114,6 @@ const App: React.FC = () => {
             ? `Request failed with status ${status}.`
             : "Request failed. Please try again.");
         setBlockingErrorMessage(effectiveMessage);
-        if (status === 403) {
-          setIsAuthenticated(false);
-        }
         setErrorMessage(effectiveMessage);
       })
       .then(() => setIsFetching(false));
@@ -237,7 +171,7 @@ const App: React.FC = () => {
         />
       )}
       <div className="flex-grow-0 sm:w-2/3 md:w-1/2 text-center bg-orange-500 uppercase font-bold mt-4">
-        $ WELCOME TO POCKET RETRO
+        $ WELCOME TO READWISE RETRO
       </div>
       <LimitSection />
       <div className="flex-grow flex-shrink-0 sm:w-2/3 md:w-1/2 border-orange-500 mt-4 p-2 border-2 mb-4">
@@ -248,21 +182,12 @@ const App: React.FC = () => {
             handleClick={handleClick}
           />
         ))}
-        {consumerKey === null && <Form submitValue={setConsumerKey} />}
-        {!isAuthenticated && consumerKey && (
-          <div className="text-orange-500 font-thin font-base">
-            Attempting to Authenticate...
-          </div>
-        )}
-        {isAuthenticated && isFetching && (
+        {isFetching && (
           <div className="text-orange-500 font-thin font-base">Loading...</div>
         )}
         {errorMessage && (
           <div className="text-orange-500 font-thin font-base">
-            {errorMessage}{" "}
-            <span style={{ cursor: "pointer" }} onClick={removeKey}>
-              {"(Reset consumer key?)"}
-            </span>
+            {errorMessage}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Migrate from Pocket to Readwise as the article source.

- **Backend**: Replace Pocket OAuth + API with Readwise token auth and Reader API (`/api/v3/list`, `/api/v3/update`)
- **Frontend**: Remove OAuth/consumer-key flow, simplify article fetching, and add a blocking error dialog for failures
- **Branding**: Rename to "Readwise Retro" across README and UI
- Net **-123 lines** — removes the entire Pocket OAuth handshake (request token, authorize, cookie management)