### PR TITLE
Improve API error UX with inline error boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2026-02-22
+
+### Improved error handling UX
+
+- Replaced modal error dialog with an inline error state inside the links box. When the API fails, all article links are hidden and replaced with the error message and a Retry button.
+- Articles are now restored to the list when an archive call fails, preventing "lost" articles that reappear on next load.
+- Removed automatic re-fetching when the article list empties. Articles are fetched once on page load only, fixing a race condition where the last article click would trigger a re-fetch before the archive call completed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Replaced modal error dialog with an inline error state inside the links box. When the API fails, all article links are hidden and replaced with the error message and a Retry button.
 - Articles are now restored to the list when an archive call fails, preventing "lost" articles that reappear on next load.
 - Removed automatic re-fetching when the article list empties. Articles are fetched once on page load only, fixing a race condition where the last article click would trigger a re-fetch before the archive call completed.
+- Removed the article limit UI — the backend never respected the limit parameter.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Readwise Retro
 
-Pocket updated their design recently. I love it but it has affected my main usecase for Pocket.
-
 This simple application fetches article links and archives them when you open the original article in a new tab.
 Powered by a Python service using Bottle and a Typescript React frontend. PRs and issues are welcome!
 
 ```shell
-docker run -d -p 127.0.0.1:3210:8080 --name pocket_retro seanbe/pocket_retro
+docker run -d -p 127.0.0.1:3210:8080 --name readwise-retro seanbe/pocket_retro
 ```
 
 Check out [seanbe/pocket_retro](https://hub.docker.com/r/seanbe/pocket_retro) for other tagged images.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,30 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import { Article, ArticleItem } from "./components/articles";
-
-type BlockingErrorProps = {
-  message: string;
-  onConfirm: () => void;
-};
-
-const BlockingErrorDialog: React.FC<BlockingErrorProps> = ({
-  message,
-  onConfirm,
-}) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
-    <div className="bg-gray-900 border border-orange-500 text-orange-500 px-6 py-4 w-11/12 max-w-md shadow-lg">
-      <p className="mb-4 text-center">{message}</p>
-      <button
-        className="w-full border border-orange-500 px-3 py-2 uppercase font-bold tracking-wide"
-        onClick={onConfirm}
-        autoFocus
-        type="button"
-      >
-        Confirm
-      </button>
-    </div>
-  </div>
-);
 
 const parseJSON = (response: any) => {
   return new Promise((resolve) =>
@@ -68,9 +44,17 @@ const App: React.FC = () => {
   const [allArticles, setArticles]: [Article[], Function] = useState([]);
   const [isFetching, setIsFetching]: [boolean, Function] = useState(false);
   const [errorMessage, setErrorMessage]: [string, Function] = useState("");
-  const [blockingErrorMessage, setBlockingErrorMessage] = useState<
-    string | null
-  >(null);
+  const [isError, setIsError] = useState(false);
+  const hasFetched = useRef(false);
+
+  const setError = (msg: string) => {
+    setErrorMessage(msg);
+    setIsError(true);
+  };
+  const clearError = () => {
+    setErrorMessage("");
+    setIsError(false);
+  };
 
   const updateArticleLimit = (newLimit: number) => {
     const [MIN, MAX]: number[] = [5, 50];
@@ -87,17 +71,14 @@ const App: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (allArticles.length > 0 && articleLimit !== allArticles.length) {
-      fetchArticles();
-    }
-  }, [articleLimit]);
-
-  useEffect(() => {
-    if (allArticles.length !== 0 || errorMessage) return;
-    setIsFetching(true);
-  }, [allArticles, errorMessage]);
+    if (hasFetched.current) return;
+    hasFetched.current = true;
+    fetchArticles();
+  }, []);
 
   const fetchArticles = () => {
+    clearError();
+    setIsFetching(true);
     return request(`/api/articles?offset=0&limit=${articleLimit}`, {})
       .then((res: any) => {
         const { articles }: { articles: Article[] } = res.data;
@@ -113,19 +94,18 @@ const App: React.FC = () => {
           (status
             ? `Request failed with status ${status}.`
             : "Request failed. Please try again.");
-        setBlockingErrorMessage(effectiveMessage);
-        setErrorMessage(effectiveMessage);
+        setError(effectiveMessage);
       })
       .then(() => setIsFetching(false));
   };
 
-  useEffect(() => {
-    isFetching && fetchArticles();
-  }, [isFetching]);
 
   const handleClick = (id: string) => {
-    // list will only contain at most 10 elements so filter is fine.
+    const article = allArticles.find((a) => a.id === id);
     setArticles((existing: Article[]) => existing.filter((a) => a.id !== id));
+    if (allArticles.length === 1) {
+      setErrorMessage("No more articles.");
+    }
     request(`/api/articles/${id}`, { method: "DELETE" }).catch((error) => {
       const { status, message } = error || {};
       const effectiveMessage =
@@ -133,9 +113,15 @@ const App: React.FC = () => {
         (status
           ? `Failed to archive article (status ${status}).`
           : "Failed to archive article. Check API.");
-      setBlockingErrorMessage(effectiveMessage);
-      setErrorMessage(effectiveMessage);
+      if (article) {
+        setArticles((existing: Article[]) => [article, ...existing]);
+      }
+      setError(effectiveMessage);
     });
+  };
+
+  const handleRetry = () => {
+    fetchArticles();
   };
 
   const LimitSection = () => {
@@ -164,31 +150,37 @@ const App: React.FC = () => {
 
   return (
     <div className="h-screen flex items-center flex-col font-mono p-1">
-      {blockingErrorMessage && (
-        <BlockingErrorDialog
-          message={blockingErrorMessage}
-          onConfirm={() => setBlockingErrorMessage(null)}
-        />
-      )}
       <div className="flex-grow-0 sm:w-2/3 md:w-1/2 text-center bg-orange-500 uppercase font-bold mt-4">
         $ WELCOME TO READWISE RETRO
       </div>
       <LimitSection />
-      <div className="flex-grow flex-shrink-0 sm:w-2/3 md:w-1/2 border-orange-500 mt-4 p-2 border-2 mb-4">
-        {allArticles.map((article: Article) => (
-          <ArticleItem
-            key={article.id}
-            article={article}
-            handleClick={handleClick}
-          />
-        ))}
-        {isFetching && (
-          <div className="text-orange-500 font-thin font-base">Loading...</div>
-        )}
-        {errorMessage && (
-          <div className="text-orange-500 font-thin font-base">
-            {errorMessage}
+      <div className="flex-grow flex-shrink-0 flex flex-col sm:w-2/3 md:w-1/2 border-orange-500 mt-4 p-2 border-2 mb-4">
+        {isError ? (
+          <div className="text-orange-500 flex flex-col items-center justify-center h-full">
+            <div className="font-thin mb-3">{errorMessage}</div>
+            <button
+              onClick={handleRetry}
+              type="button"
+              className="border border-orange-500 px-3 py-1 uppercase font-bold tracking-wide hover:bg-orange-500 hover:text-black"
+            >
+              Retry
+            </button>
           </div>
+        ) : isFetching ? (
+          <div className="text-orange-500 font-thin">Loading...</div>
+        ) : (
+          <>
+            {allArticles.map((article: Article) => (
+              <ArticleItem
+                key={article.id}
+                article={article}
+                handleClick={handleClick}
+              />
+            ))}
+            {errorMessage && (
+              <div className="text-orange-500 font-thin">{errorMessage}</div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 
 import { Article, ArticleItem } from "./components/articles";
 
@@ -40,12 +40,10 @@ const request = (url: string, options: any) => {
 };
 
 const App: React.FC = () => {
-  const [articleLimit, setArticleLimit] = useState<number>(30);
   const [allArticles, setArticles]: [Article[], Function] = useState([]);
   const [isFetching, setIsFetching]: [boolean, Function] = useState(false);
   const [errorMessage, setErrorMessage]: [string, Function] = useState("");
   const [isError, setIsError] = useState(false);
-  const hasFetched = useRef(false);
 
   const setError = (msg: string) => {
     setErrorMessage(msg);
@@ -56,30 +54,14 @@ const App: React.FC = () => {
     setIsError(false);
   };
 
-  const updateArticleLimit = (newLimit: number) => {
-    const [MIN, MAX]: number[] = [5, 50];
-    const limit = Math.min(MAX, Math.max(MIN, newLimit));
-    setArticleLimit(limit);
-    localStorage.setItem("articleLimit", limit.toString());
-  };
-
   useEffect(() => {
-    const limit: null | string = localStorage.getItem("articleLimit");
-    if (limit !== null && parseInt(limit, 10)) {
-      updateArticleLimit(parseInt(limit, 10));
-    }
-  }, []);
-
-  useEffect(() => {
-    if (hasFetched.current) return;
-    hasFetched.current = true;
     fetchArticles();
   }, []);
 
   const fetchArticles = () => {
     clearError();
     setIsFetching(true);
-    return request(`/api/articles?offset=0&limit=${articleLimit}`, {})
+    return request("/api/articles", {})
       .then((res: any) => {
         const { articles }: { articles: Article[] } = res.data;
         if (articles && articles.length === 0) {
@@ -124,36 +106,11 @@ const App: React.FC = () => {
     fetchArticles();
   };
 
-  const LimitSection = () => {
-    const [value, setValue] = useState(articleLimit);
-
-    const handleKeyUp = (event: any) => {
-      event.key === "Enter" && updateArticleLimit(value);
-    };
-
-    const onChange = (e: any) => setValue(e.target.value);
-
-    return (
-      <p className="flex-grow-0 sm:w-2/3 md:w-1/2 text-center bg-orange-500 font-bold mt-4">
-        Application will attempt to retrieve
-        <input
-          onKeyUp={handleKeyUp}
-          onChange={onChange}
-          className="bg-orange-500 underline w-5 mx-1 cursor-pointer"
-          type="text"
-          value={value}
-        />
-        articles untill exhausted.
-      </p>
-    );
-  };
-
   return (
     <div className="h-screen flex items-center flex-col font-mono p-1">
       <div className="flex-grow-0 sm:w-2/3 md:w-1/2 text-center bg-orange-500 uppercase font-bold mt-4">
         $ WELCOME TO READWISE RETRO
       </div>
-      <LimitSection />
       <div className="flex-grow flex-shrink-0 flex flex-col sm:w-2/3 md:w-1/2 border-orange-500 mt-4 p-2 border-2 mb-4">
         {isError ? (
           <div className="text-orange-500 flex flex-col items-center justify-center h-full">


### PR DESCRIPTION
## Summary

- Replaces the modal error dialog with an inline error state inside the links box — when the API fails, all article links are hidden and replaced with the error message and a centered Retry button, preventing further interaction while the API is down
- Restores articles to the list when an archive (DELETE) call fails, so articles aren't silently lost from local state
- Fetches articles once on mount only, removing the auto-refetch-when-empty behavior that caused a race condition where clicking the last article triggered a premature re-fetch before the archive call completed
- Shows "No more articles." immediately when the last article is clicked